### PR TITLE
v0.1.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4] - 2022-11-25
+
+### Changed
+
+- The `PublicAccessBlockConfiguration` should represent itself as be `publicAccessBlockConfiguration`
+- `v0.1.3` build did not include control names
+
 ## [0.1.3] - 2022-11-06
 
 ### Changed

--- a/src/s3/index.ts
+++ b/src/s3/index.ts
@@ -5,9 +5,9 @@ import { ControlProcedure } from '@elemental-clouds/hydrogen/Common';
  * @example 
 ```typescript
 // Ensure all blocks are enabled
-export const PublicAccessBlockConfiguration: ControlProcedure = {
+export const publicAccessBlockConfiguration: ControlProcedure = {
   description: 'ensures all public access blocks are enabled',
-  name: 'PublicAccessBlockConfiguration',
+  name: 'publicAccessBlockConfiguration',
   procedure: [
     {
       $includes: [
@@ -31,9 +31,9 @@ export const PublicAccessBlockConfiguration: ControlProcedure = {
  * ensures all public access blocks are enabled
  * @example
 ```typescript
-export const PublicAccessBlockConfiguration: ControlProcedure = {
+export const publicAccessBlockConfiguration: ControlProcedure = {
   description: 'ensures all public access blocks are enabled',
-  name: 'PublicAccessBlockConfiguration',
+  name: 'publicAccessBlockConfiguration',
   procedure: [
     {
       $includes: [
@@ -52,9 +52,9 @@ export const PublicAccessBlockConfiguration: ControlProcedure = {
   ],
 ```
  */
-export const PublicAccessBlockConfiguration: ControlProcedure = {
+export const publicAccessBlockConfiguration: ControlProcedure = {
   description: 'ensures all public access blocks are enabled',
-  name: 'PublicAccessBlockConfiguration',
+  name: 'publicAccessBlockConfiguration',
   procedure: [
     {
       $includes: [


### PR DESCRIPTION
## [0.1.4] - 2022-11-25

### Changed

- The `PublicAccessBlockConfiguration` should represent itself as be `publicAccessBlockConfiguration`
- `v0.1.3` build did not include control names